### PR TITLE
Rebuild rustc with Win7 tier3 target support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     tags: [ 'v*' ]
   pull_request:
     branches: [ main ]
-
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -36,7 +36,33 @@ jobs:
       - name: Build release
         run: make release
 
-      - name: Build release
+      - name: Add win7 toolchain env vars
+        run: |
+          {
+            # Gotcha: if any overrides are used below in the call to
+            # `make win7`, they need to be reflected here as well.
+            make --no-print-directory print-TOOLCHAIN_WIN7_BACKEND
+            make --no-print-directory -C win7-rustc print-RUST_STAGE2_DIR
+          } >> $GITHUB_ENV
+
+      # Use a cache action to avoid rebuilding the compiler every time
+      # the CI runs
+      - name: Cache Win7 rustc
+        id: win7-rustc
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.RUST_STAGE2_DIR }}
+          key: |
+            ${{ runner.os }}-rust-toolchain-${{ env.TOOLCHAIN_WIN7_BACKEND }}
+
+      # If the cache was hit, register the cached compiler with rustup
+      - if: ${{ steps.win7-rustc.outputs.cache-hit == 'true' }}
+        name: Register cached toolchain
+        run: |
+          make -C win7-rustc register-toolchain \
+            TOOLCHAIN=${{ env.TOOLCHAIN_WIN7_BACKEND }}
+      
+      - name: Build Win7 release
         run: make win7
 
       - name: Gather artifacts

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "backend"
 version = "3.0.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 common = { path = "../common", features = [ "backend" ] }

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -285,7 +285,7 @@ pub fn main(level: common::Level) {
 
 // rundll32.exe soxy.dll,Main
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(non_snake_case, unused_variables)]
 extern "system" fn Main() {
     loop {
@@ -293,7 +293,7 @@ extern "system" fn Main() {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 #[allow(non_snake_case, unused_variables, clippy::missing_safety_doc)]
 pub unsafe extern "system" fn DllMain(
     dll_module: ws::Win32::Foundation::HINSTANCE,

--- a/backend/src/svc/high.rs
+++ b/backend/src/svc/high.rs
@@ -44,7 +44,7 @@ impl<'a> Svc<'a> {
             (self.query)(
                 wtshandle,
                 ws::Win32::System::RemoteDesktop::WTSVirtualClientData,
-                &mut client_dataptr,
+                ptr::from_mut(&mut client_dataptr),
                 &mut len,
             )
         };

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "common"
 version = "3.0.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 copyrs = { version = "0", default-features = false }

--- a/common/src/ftp/frontend.rs
+++ b/common/src/ftp/frontend.rs
@@ -132,7 +132,7 @@ fn cmd_retr(
     fpath.push(path);
     to_data.send(protocol::DataCommand::Retr(fpath.to_string_lossy().into()))?;
     Ok(vec![
-        "125 Data connection already open; transfer starting".into()
+        "125 Data connection already open; transfer starting".into(),
     ])
 }
 
@@ -165,7 +165,7 @@ fn cmd_stor(
     fpath.push(path);
     to_data.send(protocol::DataCommand::Stor(fpath.to_string_lossy().into()))?;
     Ok(vec![
-        "125 Data connection already open; transfer starting".into()
+        "125 Data connection already open; transfer starting".into(),
     ])
 }
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -16,8 +16,7 @@ mod log;
 #[cfg(feature = "backend")]
 mod util;
 
-pub const VIRTUAL_CHANNEL_NAME: &ffi::CStr =
-    unsafe { ffi::CStr::from_bytes_with_nul_unchecked(b"SOXY\x00") };
+pub const VIRTUAL_CHANNEL_NAME: &ffi::CStr = c"SOXY";
 
 pub enum Level {
     Off,

--- a/common/src/util.rs
+++ b/common/src/util.rs
@@ -25,7 +25,7 @@ pub(crate) fn find_best_address() -> Result<BestAddress, network_interface::Erro
                             net::IpAddr::V4(mask) => {
                                 best_cidr4 = Some((
                                     ip,
-                                    u8::try_from(u32::from_be_bytes(mask.octets()).count_ones())
+                                    u8::try_from(mask.to_bits().count_ones())
                                         .expect("too large v4 mask"),
                                 ));
                             }
@@ -33,10 +33,8 @@ pub(crate) fn find_best_address() -> Result<BestAddress, network_interface::Erro
                         },
                         Some((_, best_mask)) => {
                             let mask_nb_ones = match mask {
-                                net::IpAddr::V4(mask) => {
-                                    u8::try_from(u32::from_be_bytes(mask.octets()).count_ones())
-                                        .expect("too large v4 mask")
-                                }
+                                net::IpAddr::V4(mask) => u8::try_from(mask.to_bits().count_ones())
+                                    .expect("too large v4 mask"),
                                 net::IpAddr::V6(_) => unreachable!(),
                             };
 
@@ -51,7 +49,7 @@ pub(crate) fn find_best_address() -> Result<BestAddress, network_interface::Erro
                             net::IpAddr::V6(mask) => {
                                 best_cidr6 = Some((
                                     ip,
-                                    u8::try_from(u128::from_be_bytes(mask.octets()).count_ones())
+                                    u8::try_from(mask.to_bits().count_ones())
                                         .expect("too large v6 mask"),
                                 ));
                             }
@@ -59,10 +57,8 @@ pub(crate) fn find_best_address() -> Result<BestAddress, network_interface::Erro
                         },
                         Some((_, best_mask)) => {
                             let mask_nb_ones = match mask {
-                                net::IpAddr::V6(mask) => {
-                                    u8::try_from(u128::from_be_bytes(mask.octets()).count_ones())
-                                        .expect("too large v6 mask")
-                                }
+                                net::IpAddr::V6(mask) => u8::try_from(mask.to_bits().count_ones())
+                                    .expect("too large v6 mask"),
                                 net::IpAddr::V4(_) => unreachable!(),
                             };
 

--- a/win7-rustc/.gitignore
+++ b/win7-rustc/.gitignore
@@ -1,0 +1,2 @@
+rust-src/
+rust-build/

--- a/win7-rustc/Makefile
+++ b/win7-rustc/Makefile
@@ -1,0 +1,66 @@
+# This Makefile is used to rebuild a rust toolchain.
+# It is intendended for the Win7 target that is no longer a Tier1 architecture
+# for rustc. Because it is now Tier3, we need to rebuild it ourselves.
+
+# Git tag of the compiler version to build
+TAG ?= 1.87.0
+
+# Name of the toolchain being built
+TOOLCHAIN ?= win7-$(TAG)
+
+HOST ?= $(shell rustc -vV | grep "^host:" | awk '{print $$2}')
+TARGETS ?= x86_64-win7-windows-gnu
+
+# Rustc git repo
+RUST_GIT ?= https://github.com/rust-lang/rust.git
+
+# Directory in which to checkout rustc source
+RUST_SRC ?= $(CURDIR)/rust-src
+
+# Directory in which to build the compiler
+RUST_BUILD ?= $(CURDIR)/rust-build
+
+# Directory containing the stage2 once it is built
+RUST_STAGE2_DIR ?= $(RUST_BUILD)/build/$(HOST)/stage2
+
+SHELL := bash
+
+.PHONY: build
+build: setup
+	rustup toolchain list | grep -q $(TOOLCHAIN) || {             \
+		echo Building toolchain: $(TOOLCHAIN);                    \
+		pushd $(RUST_BUILD)                                       \
+		&& $(abspath $(RUST_SRC))/x build                         \
+			--host=$(HOST)                                        \
+			--target=$(shell tr ' ' ',' <<< "$(TARGETS) $(HOST)") \
+		&& popd                                                   \
+		&& $(MAKE) register-toolchain                             \
+			TOOLCHAIN=$(TOOLCHAIN)                                \
+			RUST_STAGE2_DIR=$(RUST_STAGE2_DIR);                   \
+	}
+
+.PHONY: setup
+setup:
+	[ -d $(RUST_SRC) ] || {                                       \
+		mkdir -p $(dir $(RUST_SRC))                               \
+		&& git clone $(RUST_GIT) $(RUST_SRC)                      \
+		&& cd $(RUST_SRC)                                         \
+		&& git checkout $(TAG);                                   \
+	}
+	mkdir -p $(RUST_BUILD)
+	cp bootstrap.toml $(RUST_BUILD)
+
+.PHONY: register-toolchain
+register-toolchain:
+	rustup toolchain link $(TOOLCHAIN) $(RUST_STAGE2_DIR)
+
+print-%:
+	@echo $*=$($*)
+
+.PHONY: clean
+clean:
+	cd $(RUST_BUILD) && ./x clean
+
+.PHONY: distclean
+distclean:
+	rm -Rf $(RUST_BUILD) $(RUST_SRC)

--- a/win7-rustc/bootstrap.toml
+++ b/win7-rustc/bootstrap.toml
@@ -1,0 +1,29 @@
+# Includes one of the default files in src/bootstrap/defaults
+#
+# The "compiler" profile favors a faster build of the compiler itself at the
+# expense of the performance of the compiler itself. Since the compiler being
+# built here is disproportionately more complex than Soxy, the trade-off skews
+# towards the shorter compiler build time.
+profile = "compiler"
+change-id = 138986
+
+# Turn lots of stuff off since all we want is the Win7 compiler
+[build]
+compiler-docs = false
+target = ["x86_64-win7-windows-gnu", "x86_64-unknown-linux-gnu"]
+host = ["x86_64-unknown-linux-gnu"]
+build-stage = 2
+
+[rust]
+debug-logging = false
+debug-assertions = false
+backtrace-on-ice = false
+incremental = false
+
+[llvm]
+download-ci-llvm = "if-unchanged"
+
+[target.x86_64-win7-windows-gnu]
+linker = "x86_64-w64-mingw32-gcc" 
+cc = "x86_64-w64-mingw32-gcc"
+cxx = "x86_64-w64-mingw32-g++"


### PR DESCRIPTION
Instead of using the last version of rustc with support for Win7, this PR recompiles rustc for the Win7 target. The advantage is to avoid having Win7 support in soxy become a limiting factor for adopting newer compiler features.

- Build a version of rustc (configured in [`Makefile`](https://github.com/wb-airbus/soxy/blob/0388259/Makefile#L23)) used for compilation of Win7 targets
- Use a CI cache to avoid rebuilding rustc when possible
- Revert changes from #4fc505c that were needed to compile with rustc 1.75